### PR TITLE
Use proper config files for build configs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/.github/workflows/rust-wasm-pages.yml
+++ b/.github/workflows/rust-wasm-pages.yml
@@ -2,7 +2,7 @@ name: Rust WASM Page
 
 on:
   push:
-    branches: [ "master", "update_build" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
   workflow_dispatch:

--- a/.github/workflows/rust-wasm-pages.yml
+++ b/.github/workflows/rust-wasm-pages.yml
@@ -2,11 +2,11 @@ name: Rust WASM Page
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "update_build" ]
   pull_request:
     branches: [ "master" ]
-  workflow_dispatch: 
-    
+  workflow_dispatch:
+
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,15 +19,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install Rust
-      uses: brndnmtthws/rust-action-rustup@v1.0.0
-      with:
-        toolchain: nightly
-        targets: wasm32-unknown-unknown
-        components: cargo, rustc, rust-std
-
     - name: Build
-      run: RUSTFLAGS=--cfg=web_sys_unstable_apis cargo build --target wasm32-unknown-unknown -F wasm --release
+      run: cargo build --target wasm32-unknown-unknown -F wasm --release
 
     - name: Install wasm-bindgen
       run: cargo install wasm-bindgen-cli
@@ -39,7 +32,7 @@ jobs:
       uses: actions/upload-pages-artifact@v1
       with:
         path: web/
-  
+
   deploy:
 
     needs:

--- a/localdeploy.sh
+++ b/localdeploy.sh
@@ -1,5 +1,5 @@
 # script requires rust cargo with nightly wasm32-unknown-unknown target
 # and wasm-bindgen, which can be installed with cargo install wasm-bindgen-cli
 
-RUSTFLAGS=--cfg=web_sys_unstable_apis cargo build --target wasm32-unknown-unknown -F wasm --release
+cargo build --target wasm32-unknown-unknown -F wasm --release
 wasm-bindgen target/wasm32-unknown-unknown/release/rls.wasm --out-dir web/wasm --target web

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2023-10-17"
+components = [ "cargo", "rustc", "rust-std" ]
+targets = [ "wasm32-unknown-unknown" ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 #![allow(incomplete_features)]
 #![feature(generic_const_exprs)]
 #![feature(int_roundings)]
-#![feature(lazy_cell)]
 #![feature(thread_id_value)]
 
 use std::{

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -424,7 +424,7 @@ impl PropertyEditor {
                             }),
                     );
                 for str in self.ids_cache_remove.iter() {
-                    self.ids_cache.remove(str.deref());
+                    self.ids_cache.remove(str);
                 }
             }
             stores.push(store);
@@ -453,7 +453,7 @@ impl PropertyEditor {
 
                 let equal = props.windows(2).all(|w| w[0].1.imp().equals(w[1].1.imp()));
 
-                
+
                 ui.label(id.name.deref());
 
                 if let Some(old) = props[0].1.imp_mut().ui(ui, !equal) {

--- a/test_build_combinations.sh
+++ b/test_build_combinations.sh
@@ -4,4 +4,4 @@ cargo check -F single_thread
 
 cargo check -F wasm --target wasm32-unknown-unknown
 
-RUSTFLAGS=--cfg=web_sys_unstable_apis cargo check -F wasm --target wasm32-unknown-unknown
+RUSTFLAGS= cargo check -F wasm --target wasm32-unknown-unknown


### PR DESCRIPTION
This PR moves the RUSTFLAGS variable into `.cargo/config.toml` and adds a rust-toolchain.toml to configure which toolchain to use. I currently pinned it to the version of today, but you can easily remove the date and just require nightly in general. Fixes #1 